### PR TITLE
Added opt arg for getting coverage from index.html (output by nosetests)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,13 +40,14 @@ It's important that you run ``coverage-badge`` from the directory where the
 
 The full usage text::
 
-    usage: __main__.py [-h] [-o FILEPATH] [-q] [-v]
+    usage: __main__.py [-h] [-o FILEPATH] [-g HTML] [-q] [-v]
 
     Generate coverage badges for Coverage.py.
 
     optional arguments:
       -h, --help   show this help message and exit
       -o FILEPATH  Save the file to the specified path.
+      -n, --html HTML  Get coverage from index.html output by nosetests.
       -q           Don't output any non-error messages.
       -v           Show version.
 

--- a/coverage_badge/__main__.py
+++ b/coverage_badge/__main__.py
@@ -36,11 +36,11 @@ def get_total():
     return '{0:.0f}'.format(total)
 
 
-def get_from_html(index_html):  # new
+def get_from_html(index_html):
     """
     Return the total from index.html.
     """
-    with open(index_html, "rb") as f:
+    with open(index_html, "r") as f:
         html_content = f.read()
     pattern = '<span class="pc_cov">(.*)%</span>'
     pct = re.findall(pattern, html_content)[0]
@@ -64,8 +64,8 @@ def parse_args(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-o', dest='filepath',
             help='Save the file to the specified path.')
-    parser.add_argument('-n', '--html', dest='html',                    # new
-            help='Get coverage from index.html output by nosetests.')   # new
+    parser.add_argument('-d', '--html', dest='html',
+            help='Get coverage from index.html output by nosetests.')
     parser.add_argument('-q', dest='quiet', action='store_true',
             help='Don\'t output any non-error messages.')
     parser.add_argument('-v', dest='print_version', action='store_true',
@@ -124,10 +124,10 @@ def main(argv=None):
 
     # Generate badge
     try:
-        if args.html and os.path.exists(args.html):     # new
-            total = get_from_html(args.html)            # new
-        else:                                           # new
-            total = get_total()                         # moved
+        if args.html and os.path.exists(args.html):
+            total = get_from_html(args.html)
+        else:
+            total = get_total()
     except coverage.misc.CoverageException as e:
         print('Error: {} Did you run coverage first?'.format(e))
         sys.exit(1)

--- a/coverage_badge/__main__.py
+++ b/coverage_badge/__main__.py
@@ -6,6 +6,7 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 import os
 import sys
+import re
 import argparse
 import pkg_resources
 try:
@@ -35,6 +36,17 @@ def get_total():
     return '{0:.0f}'.format(total)
 
 
+def get_from_html(index_html):  # new
+    """
+    Return the total from index.html.
+    """
+    with open(index_html, "rb") as f:
+        html_content = f.read()
+    pattern = '<span class="pc_cov">(.*)%</span>'
+    pct = re.findall(pattern, html_content)[0]
+    return pct
+
+
 def get_badge(total):
     """
     Read the SVG template from the package, update total, return SVG as a
@@ -52,6 +64,8 @@ def parse_args(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-o', dest='filepath',
             help='Save the file to the specified path.')
+    parser.add_argument('-n', '--html', dest='html',                    # new
+            help='Get coverage from index.html output by nosetests.')   # new
     parser.add_argument('-q', dest='quiet', action='store_true',
             help='Don\'t output any non-error messages.')
     parser.add_argument('-v', dest='print_version', action='store_true',
@@ -110,7 +124,10 @@ def main(argv=None):
 
     # Generate badge
     try:
-        total = get_total()
+        if args.html and os.path.exists(args.html):     # new
+            total = get_from_html(args.html)            # new
+        else:                                           # new
+            total = get_total()                         # moved
     except coverage.misc.CoverageException as e:
         print('Error: {} Did you run coverage first?'.format(e))
         sys.exit(1)


### PR DESCRIPTION
Great little package here! But it was giving me a different coverage % than what the index.html (and other files) said I had and I'd like to use that %.  
I ran nosetests like this: `nosetests --with-coverage --cover-package=<pkg> --cover-html`  

This is my first contribution to another person's work, so thanks for considering my request.  
