### PR TITLE
Different color badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 *.egg-info/
 .cache/
 .coverage
+venv/

--- a/README.rst
+++ b/README.rst
@@ -38,22 +38,22 @@ It's important that you run ``coverage-badge`` from the directory where the
 
 Different colors for cover ranges:
 
-.. image:: ./media/15.svg
+.. image:: https://cdn.rawgit.com/samael500/coverage-badge/master/media/15.svg
     :alt: 15%
 
-.. image:: ./media/45.svg
+.. image:: https://cdn.rawgit.com/samael500/coverage-badge/master/media/45.svg
     :alt: 45%
 
-.. image:: ./media/65.svg
+.. image:: https://cdn.rawgit.com/samael500/coverage-badge/master/media/65.svg
     :alt: 65%
 
-.. image:: ./media/80.svg
+.. image:: https://cdn.rawgit.com/samael500/coverage-badge/master/media/80.svg
     :alt: 80%
 
-.. image:: ./media/93.svg
+.. image:: https://cdn.rawgit.com/samael500/coverage-badge/master/media/93.svg
     :alt: 93%
 
-.. image:: ./media/97.svg
+.. image:: https://cdn.rawgit.com/samael500/coverage-badge/master/media/97.svg
     :alt: 97%
 
 ---

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,7 @@ The full usage text::
     optional arguments:
       -h, --help   show this help message and exit
       -o FILEPATH  Save the file to the specified path.
+      -f           Force overwrite image, use with -o key.
       -q           Don't output any non-error messages.
       -v           Show version.
 

--- a/README.rst
+++ b/README.rst
@@ -60,17 +60,17 @@ Different colors for cover ranges:
 
 The full usage text::
 
-    usage: __main__.py [-h] [-o FILEPATH] [-f] [-q] [-v]
+    usage: __main__.py [-h] [-o FILEPATH] [-p] [-f] [-q] [-v]
 
     Generate coverage badges for Coverage.py.
 
     optional arguments:
       -h, --help   show this help message and exit
       -o FILEPATH  Save the file to the specified path.
+      -p           Plain color mode. Standard green badge.
       -f           Force overwrite image, use with -o key.
       -q           Don't output any non-error messages.
       -v           Show version.
-
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,26 @@ either return the badge SVG to stdout::
 It's important that you run ``coverage-badge`` from the directory where the
 ``.coverage`` data file is located.
 
+Different colors for cover ranges:
+
+.. image:: ./media/15.svg
+    :alt: 15%
+
+.. image:: ./media/45.svg
+    :alt: 45%
+
+.. image:: ./media/65.svg
+    :alt: 65%
+
+.. image:: ./media/80.svg
+    :alt: 80%
+
+.. image:: ./media/93.svg
+    :alt: 93%
+
+.. image:: ./media/97.svg
+    :alt: 97%
+
 ---
 
 The full usage text::

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Different colors for cover ranges:
 
 The full usage text::
 
-    usage: __main__.py [-h] [-o FILEPATH] [-q] [-v]
+    usage: __main__.py [-h] [-o FILEPATH] [-f] [-q] [-v]
 
     Generate coverage badges for Coverage.py.
 

--- a/coverage_badge/__main__.py
+++ b/coverage_badge/__main__.py
@@ -86,6 +86,8 @@ def parse_args(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-o', dest='filepath',
             help='Save the file to the specified path.')
+    parser.add_argument('-f', dest='force', action='store_true',
+            help='Force overwrite image, use with -o key.')
     parser.add_argument('-q', dest='quiet', action='store_true',
             help='Don\'t output any non-error messages.')
     parser.add_argument('-v', dest='print_version', action='store_true',
@@ -100,7 +102,7 @@ def parse_args(argv=None):
         return parser.parse_args()
 
 
-def save_badge(badge, filepath):
+def save_badge(badge, filepath, force=False):
     """
     Save badge to the specified path.
     """
@@ -115,7 +117,7 @@ def save_badge(badge, filepath):
         path += '.svg'
 
     # Validate path (part 2)
-    if os.path.exists(path):
+    if not force and os.path.exists(path):
         print('Error: "{}" already exists.'.format(path))
         sys.exit(1)
 
@@ -152,7 +154,7 @@ def main(argv=None):
 
     # Show or save output
     if args.filepath:
-        path = save_badge(badge, args.filepath)
+        path = save_badge(badge, args.filepath, args.force)
         if not args.quiet:
             print('Saved badge to {}'.format(path))
     else:

--- a/coverage_badge/__main__.py
+++ b/coverage_badge/__main__.py
@@ -87,7 +87,7 @@ def parse_args(argv=None):
     parser.add_argument('-o', dest='filepath',
             help='Save the file to the specified path.')
     parser.add_argument('-p', dest='plain_color', action='store_true',
-            help='Standard green badge.')
+            help='Plain color mode. Standard green badge.')
     parser.add_argument('-f', dest='force', action='store_true',
             help='Force overwrite image, use with -o key.')
     parser.add_argument('-q', dest='quiet', action='store_true',

--- a/coverage_badge/__main__.py
+++ b/coverage_badge/__main__.py
@@ -17,6 +17,25 @@ except ImportError:
 __version__ = '0.1.2'
 
 
+COLORS = {
+    'brightgreen': '#4c1',
+    'green': '#97CA00',
+    'yellowgreen': '#a4a61d',
+    'yellow': '#dfb317',
+    'orange': '#fe7d37',
+    'red': '#e05d44'
+}
+
+COLOR_RANGES [
+    (95, 'brightgreen'),
+    (90, 'green'),
+    (75, 'yellowgreen'),
+    (60, 'yellow'),
+    (40, 'orange'),
+    (0, 'red'),
+]
+
+
 class Devnull(object):
     """
     A file like object that does nothing.
@@ -35,6 +54,14 @@ def get_total():
     return '{0:.0f}'.format(total)
 
 
+def get_color(total):
+    """
+    Return color for current coverage precent
+    """
+    for range_, color in COLOR_RANGES:
+        if total >= range_:
+            return COLOR[color]
+
 def get_badge(total):
     """
     Read the SVG template from the package, update total, return SVG as a
@@ -42,7 +69,8 @@ def get_badge(total):
     """
     template_path = os.path.join('templates', 'flat.svg')
     template = pkg_resources.resource_string(__name__, template_path).decode('utf8')
-    return template.replace('{{ total }}', total)
+    color = get_color(total)
+    return template.replace('{{ total }}', total).replace('{{ color }}', color)
 
 
 def parse_args(argv=None):

--- a/coverage_badge/__main__.py
+++ b/coverage_badge/__main__.py
@@ -86,6 +86,8 @@ def parse_args(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-o', dest='filepath',
             help='Save the file to the specified path.')
+    parser.add_argument('-p', dest='plain_color', action='store_true',
+            help='Standard green badge.')
     parser.add_argument('-f', dest='force', action='store_true',
             help='Force overwrite image, use with -o key.')
     parser.add_argument('-q', dest='quiet', action='store_true',
@@ -152,7 +154,7 @@ def main(argv=None):
         sys.exit(1)
 
     color = DEFAULT_COLOR if args.plain_color else get_color(total)
-    badge = get_badge(total)
+    badge = get_badge(total, color)
 
     # Show or save output
     if args.filepath:

--- a/coverage_badge/__main__.py
+++ b/coverage_badge/__main__.py
@@ -23,10 +23,11 @@ COLORS = {
     'yellowgreen': '#a4a61d',
     'yellow': '#dfb317',
     'orange': '#fe7d37',
-    'red': '#e05d44'
+    'red': '#e05d44',
+    'lightgrey': '#9f9f9f',
 }
 
-COLOR_RANGES [
+COLOR_RANGES = [
     (95, 'brightgreen'),
     (90, 'green'),
     (75, 'yellowgreen'),
@@ -58,9 +59,14 @@ def get_color(total):
     """
     Return color for current coverage precent
     """
+    try:
+        xtotal = int(total)
+    except ValueError:
+        return COLORS['lightgrey']
     for range_, color in COLOR_RANGES:
-        if total >= range_:
-            return COLOR[color]
+        if xtotal >= range_:
+            return COLORS[color]
+
 
 def get_badge(total):
     """

--- a/coverage_badge/__main__.py
+++ b/coverage_badge/__main__.py
@@ -17,6 +17,7 @@ except ImportError:
 __version__ = '0.1.2'
 
 
+DEFAULT_COLOR = '#a4a61d'
 COLORS = {
     'brightgreen': '#4c1',
     'green': '#97CA00',
@@ -68,14 +69,13 @@ def get_color(total):
             return COLORS[color]
 
 
-def get_badge(total):
+def get_badge(total, color=DEFAULT_COLOR):
     """
     Read the SVG template from the package, update total, return SVG as a
     string.
     """
     template_path = os.path.join('templates', 'flat.svg')
     template = pkg_resources.resource_string(__name__, template_path).decode('utf8')
-    color = get_color(total)
     return template.replace('{{ total }}', total).replace('{{ color }}', color)
 
 
@@ -150,6 +150,8 @@ def main(argv=None):
     except coverage.misc.CoverageException as e:
         print('Error: {} Did you run coverage first?'.format(e))
         sys.exit(1)
+
+    color = DEFAULT_COLOR if args.plain_color else get_color(total)
     badge = get_badge(total)
 
     # Show or save output

--- a/coverage_badge/templates/flat.svg
+++ b/coverage_badge/templates/flat.svg
@@ -8,7 +8,7 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="{{ color }}" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">

--- a/media/15.svg
+++ b/media/15.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>

--- a/media/15.svg
+++ b/media/15.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#e05d44" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">15%</text>
+        <text x="80" y="14">15%</text>
+    </g>
+</svg>

--- a/media/45.svg
+++ b/media/45.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>

--- a/media/45.svg
+++ b/media/45.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#fe7d37" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">45%</text>
+        <text x="80" y="14">45%</text>
+    </g>
+</svg>

--- a/media/65.svg
+++ b/media/65.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>

--- a/media/65.svg
+++ b/media/65.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">65%</text>
+        <text x="80" y="14">65%</text>
+    </g>
+</svg>

--- a/media/80.svg
+++ b/media/80.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>

--- a/media/80.svg
+++ b/media/80.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">80%</text>
+        <text x="80" y="14">80%</text>
+    </g>
+</svg>

--- a/media/93.svg
+++ b/media/93.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>

--- a/media/93.svg
+++ b/media/93.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#97CA00" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">93%</text>
+        <text x="80" y="14">93%</text>
+    </g>
+</svg>

--- a/media/97.svg
+++ b/media/97.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#4c1" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">97%</text>
+        <text x="80" y="14">97%</text>
+    </g>
+</svg>

--- a/media/97.svg
+++ b/media/97.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>

--- a/media/na.svg
+++ b/media/na.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>

--- a/media/na.svg
+++ b/media/na.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#9f9f9f" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">na%</text>
+        <text x="80" y="14">na%</text>
+    </g>
+</svg>

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -38,3 +38,18 @@ def test_svg_output(cb, capsys):
     assert out.startswith('<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">')
     assert '<text x="80" y="14">79%</text>' in out
     assert out.endswith('</svg>\n')
+
+
+def test_color_ranges(cb, capsys):
+    """
+    Test color total value
+    """
+    for total, color in (('97', '#4c1'), ('93', '#97CA00'), ('80', '#a4a61d'), ('65', '#dfb317'),
+            ('45', '#fe7d37'), ('15', '#e05d44'), ('n/a', '#9f9f9f')):
+        __main__.get_total = lambda: total
+        cb.main([])
+        out, _ = capsys.readouterr()
+        row = '<path fill="%s" d="M63 0h36v20H63z"/>' % color
+        assert out.startswith('<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">')
+        assert row in out
+        assert out.endswith('</svg>\n')

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -2,6 +2,7 @@
 from __future__ import print_function, division, absolute_import, unicode_literals
 
 import sys
+from textwrap import dedent
 
 import pytest
 
@@ -51,6 +52,25 @@ def test_color_ranges(cb, capsys):
         cb.main([])
         out, _ = capsys.readouterr()
         row = '<path fill="%s" d="M63 0h36v20H63z"/>' % color
-        assert out.startswith('<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">')
+        assert out.startswith(dedent('''\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">'''))
+        assert row in out
+        assert out.endswith('</svg>\n')
+
+
+def test_plain_color_mode(cb, capsys):
+    """
+    Should get always one color in badge
+    """
+    assert __main__.DEFAULT_COLOR == '#a4a61d'
+    for total in ('97', '93', '80', '65', '45', '15', 'n/a'):
+        __main__.get_total = lambda: total
+        cb.main(['-p'])
+        out, _ = capsys.readouterr()
+        row = '<path fill="#a4a61d" d="M63 0h36v20H63z"/>'
+        assert out.startswith(dedent('''\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">'''))
         assert row in out
         assert out.endswith('</svg>\n')


### PR DESCRIPTION
Change color of badge by coverage result.
Also add `-f` flag to force overwrite output path.

![](https://cdn.rawgit.com/samael500/coverage-badge/master/media/15.svg)
![](https://cdn.rawgit.com/samael500/coverage-badge/master/media/45.svg)
![](https://cdn.rawgit.com/samael500/coverage-badge/master/media/65.svg)
![](https://cdn.rawgit.com/samael500/coverage-badge/master/media/80.svg)
![](https://cdn.rawgit.com/samael500/coverage-badge/master/media/93.svg)
![](https://cdn.rawgit.com/samael500/coverage-badge/master/media/97.svg)
