### PR TITLE
S3 Serving Fix for svg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,5 @@
 [bumpversion]
-current_version = 0.1.2
+current_version = 0.1.3
 files = setup.py coverage_badge/__main__.py
 commit = True
 tag = True
-

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.2
 files = setup.py coverage_badge/__main__.py
 commit = True
 tag = True

--- a/coverage_badge/templates/flat.svg
+++ b/coverage_badge/templates/flat.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>

--- a/example.svg
+++ b/example.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 readme = open('README.rst').read()
 
 setup(name='coverage-badge',
-      version='0.1.3',
+      version='0.1.2',
       description='Generate coverage badges for Coverage.py.',
       author='Danilo Bargen',
       author_email='mail@dbrgn.ch',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 readme = open('README.rst').read()
 
 setup(name='coverage-badge',
-      version='0.1.2',
+      version='0.1.3',
       description='Generate coverage badges for Coverage.py.',
       author='Danilo Bargen',
       author_email='mail@dbrgn.ch',

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -35,6 +35,7 @@ def test_svg_output(cb, capsys):
     """
     cb.main([])
     out, _ = capsys.readouterr()
-    assert out.startswith('<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">')
+    assert out.startsWith('<?xml version="1.0" encoding="UTF-8"?>')
+    assert '<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">' in out
     assert '<text x="80" y="14">79%</text>' in out
     assert out.endswith('</svg>\n')

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -35,7 +35,7 @@ def test_svg_output(cb, capsys):
     """
     cb.main([])
     out, _ = capsys.readouterr()
-    assert out.startsWith('<?xml version="1.0" encoding="UTF-8"?>')
+    assert out.startswith('<?xml version="1.0" encoding="UTF-8"?>')
     assert '<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">' in out
     assert '<text x="80" y="14">79%</text>' in out
     assert out.endswith('</svg>\n')


### PR DESCRIPTION
When uploading the generated icon to s3, if there is no xml tag s3
doesn't detect this is an svg and sets the wrong content/type tag on it
thus resulting in browser display issues.