### PR TITLE
Update `get_total()` to support Coverage 7.5

### DIFF
--- a/coverage_badge/__main__.py
+++ b/coverage_badge/__main__.py
@@ -67,13 +67,16 @@ def get_total():
                 return self.percent
 
         return Precision(total).pc_covered_str
-    else:  # Coverage 6.x
+    elif hasattr(coverage.results.Numbers, 'display_covered'): # Coverage 6.x < 7.5
         # NOTE: Precision is no longer set globally in the
         # `coverage.results.Numbers` class. Instead the precision must be
         # passed in as the first argument. We pull the precision from the
         # `coverage.Coverage` object because it should pull the correct
         # precision from the local .coveragerc file.
         return coverage.results.Numbers(precision=cov.config.precision).display_covered(total)
+    else: # Coverage >= 7.5
+        return coverage.results.display_covered(total, cov.config.precision)
+
 
 
 def get_color(total):


### PR DESCRIPTION
In Coverage 7.5, the `display_covered` method of Numbers was turned into a standalone function, so the `get_total()` method stopped working.

See this commit for more context: https://github.com/nedbat/coveragepy/commit/4e5027338b93fc893c5e6e82c8a234c48f0b95e7